### PR TITLE
chore: upgrade APISIX to 3.14.1

### DIFF
--- a/templates/rbdcomponent_helm.yaml
+++ b/templates/rbdcomponent_helm.yaml
@@ -50,7 +50,7 @@ items:
     name: rbd-gateway
     namespace: {{ .Release.Namespace }}
   spec:
-    image: {{ .Values.Cluster.rainbondImageRepository }}/apisix-ingress-controller:v1.8.3@{{ .Values.Cluster.rainbondImageRepository }}/apisix:3.9.1-debian-fix
+    image: {{ .Values.Cluster.rainbondImageRepository }}/apisix-ingress-controller:v1.8.3@{{ .Values.Cluster.rainbondImageRepository }}/apisix:3.14.1-debian
     imagePullPolicy: {{ .Values.Cluster.imagePullPolicy }}
     priorityComponent: true
     replicas: {{ .Values.Cluster.replicas }}


### PR DESCRIPTION
## Summary

- upgrade the default rbd-gateway APISIX image from 3.9.1-debian-fix to 3.14.1-debian
- upgrade APISIX Ingress Controller from 1.8.3 to 1.8.4

## Related

- goodrain/rainbond-operator#341

## Deployment prerequisite

Publish `registry.cn-hangzhou.aliyuncs.com/goodrain/apisix-ingress-controller:v1.8.4` before deploying this chart. The tag was not available in the registry during verification.

## Verification

- `helm lint .`
- rendered the chart with `Cluster.rainbondImageRepository=registry.cn-hangzhou.aliyuncs.com/goodrain` and verified the APISIX Ingress Controller 1.8.4 and APISIX 3.14.1 image reference

`helm lint` reports two pre-existing empty metadata.name warnings and completes with zero failures.