### PR TITLE
chore: upgrade APISIX ingress controller to 1.8.4

### DIFF
--- a/templates/rbdcomponent_helm.yaml
+++ b/templates/rbdcomponent_helm.yaml
@@ -50,7 +50,7 @@ items:
     name: rbd-gateway
     namespace: {{ .Release.Namespace }}
   spec:
-    image: {{ .Values.Cluster.rainbondImageRepository }}/apisix-ingress-controller:v1.8.3@{{ .Values.Cluster.rainbondImageRepository }}/apisix:3.14.1-debian
+    image: {{ .Values.Cluster.rainbondImageRepository }}/apisix-ingress-controller:v1.8.4@{{ .Values.Cluster.rainbondImageRepository }}/apisix:3.14.1-debian
     imagePullPolicy: {{ .Values.Cluster.imagePullPolicy }}
     priorityComponent: true
     replicas: {{ .Values.Cluster.replicas }}


### PR DESCRIPTION
## Summary
- upgrade APISIX Ingress Controller from 1.8.3 to 1.8.4
- keep the APISIX data-plane image at 3.14.1-debian

## Verification
- helm lint .
- helm template renders registry.cn-hangzhou.aliyuncs.com/goodrain/apisix-ingress-controller:v1.8.4 with APISIX 3.14.1-debian
- docker manifest inspect confirms the v1.8.4 controller image is available